### PR TITLE
Fix formatter alias sorting for aliases with keywords

### DIFF
--- a/lib/alias_formatter.ex
+++ b/lib/alias_formatter.ex
@@ -48,8 +48,11 @@ defmodule AliasFormatter do
     |> Enum.sort(fn alias_ast_1, alias_ast_2 ->
       [alias_str_1, alias_str_2] =
         [alias_ast_1, alias_ast_2]
-        |> Enum.map(fn {_, _, alias_ast} -> alias_ast end)
-        |> Enum.map(fn [{_, _, alias_ast}] -> alias_ast end)
+        |> Enum.map(fn {_, _, alias_ast_list} ->
+          {_, _, alias_ast} = alias_ast_list |> List.first()
+
+          alias_ast
+        end)
         |> Enum.map(&Enum.join(&1, "."))
 
       alias_str_1 < alias_str_2

--- a/test/alias_formatter/keyword_substitute_test.exs
+++ b/test/alias_formatter/keyword_substitute_test.exs
@@ -34,5 +34,22 @@ defmodule AliasFormatter.KeywordSubstituteTest do
 
       assert ^test_function_ast = test_function_ast |> KeywordSubstitute.substitute()
     end
+
+    test "shouldn't change alias asts" do
+      test_alias_asts = [
+        {:alias, [line: 3], [{:__aliases__, [line: 3], [:TestModuleExample, :Bbb]}]},
+        {:alias, [line: 3],
+         [
+           {:__aliases__, [line: 3], [:TestModuleExample, :Bbb]},
+           [
+             {{:__block__, [format: :keyword, line: 3], [:as]}, {:__aliases__, [line: 3], [:Aaa]}}
+           ]
+         ]}
+      ]
+
+      for test_alias_ast <- test_alias_asts do
+        assert ^test_alias_ast = test_alias_ast |> KeywordSubstitute.substitute()
+      end
+    end
   end
 end


### PR DESCRIPTION
* Fix formatter alias sorting for aliases with `as:` keywords
* Add tests